### PR TITLE
Add example docker-compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,15 @@
-# NOTE: This will give you a demo server that uses a sqlite backend, but
-# data (channels, subscriptions, and messages) WILL NOT persist after
-# the server is shut down. If you are more familiar with Docker than I
-# am, feel free to submit a PR providing instructions to make this use
-# Docker volumes to persist data between server restarts.
+FROM python:3.7.4-alpine3.10
 
-FROM python:3.7.4
-
-MAINTAINER Paul Butler "docker@paulbutler.org"
+LABEL maintainer="Paul Butler <docker@paulbutler.org>"
 
 COPY ./requirements.txt /requirements.txt
 
-RUN pip install -r requirements.txt
+# hadolint ignore=DL3018
+RUN apk add --no-cache --virtual .notify-run_deps build-base python3-dev openssl-dev libffi-dev && \
+    pip install -r requirements.txt && \
+    apk del .notify-run_deps
 
 EXPOSE 8000
+VOLUME /notify-run
+WORKDIR /notify-run
 CMD [ "gunicorn", "notify_run_server:app", "--bind=0.0.0.0:8000", "--workers=4" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.5'
+services:
+  notify-run:
+    build: ./
+    image: notify-run-server
+    restart: always
+    ports:
+      - "8000:8000"
+    volumes:
+      - data:/notify-run
+
+volumes:
+  data:


### PR DESCRIPTION
Hi @paulgb,

I was curious so I wipped up a small compose file to simplify building and running the container. With this I am now also persisting the sqlite file (since the compose file defines a volume for it).

General handling would then still need to be put into a readme.

I have also switched the base image to the Alpine flavour of the Python image. As a result the total image is now only 199MB in size (old image was 1.02GB).

I do see one error during build and one during the initial start (both were present already before my change of the base image).

Error during build:
`ERROR: notify-run-server 0.0.5 has requirement pywebpush==1.5.0, but you'll have pywebpush 1.10.0 which is incompatible.`
The build then continues. I actually do not get a push notification on my testing firefox, but am unsure if this could be the case since i access it through plain http at the moment.

Error during (initial) start:
```
Attaching to notify-run-deployment_notify-run_1
notify-run_1  | [2019-09-03 15:00:51 +0000] [1] [INFO] Starting gunicorn 19.9.0
notify-run_1  | [2019-09-03 15:00:51 +0000] [1] [INFO] Listening at: http://0.0.0.0:8000 (1)
notify-run_1  | [2019-09-03 15:00:51 +0000] [1] [INFO] Using worker: sync
notify-run_1  | [2019-09-03 15:00:51 +0000] [7] [INFO] Booting worker with pid: 7
notify-run_1  | [2019-09-03 15:00:51 +0000] [8] [INFO] Booting worker with pid: 8
notify-run_1  | [2019-09-03 15:00:51 +0000] [9] [INFO] Booting worker with pid: 9
notify-run_1  | [2019-09-03 15:00:51 +0000] [10] [INFO] Booting worker with pid: 10
notify-run_1  | [2019-09-03 15:00:53 +0000] [10] [ERROR] Exception in worker process
notify-run_1  | Traceback (most recent call last):
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1249, in _execute_context
notify-run_1  |     cursor, statement, parameters, context
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 552, in do_execute
notify-run_1  |     cursor.execute(statement, parameters)
notify-run_1  | sqlite3.OperationalError: table message already exists
notify-run_1  |
notify-run_1  | The above exception was the direct cause of the following exception:
notify-run_1  |
notify-run_1  | Traceback (most recent call last):
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
notify-run_1  |     worker.init_process()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base.py", line 129, in init_process
notify-run_1  |     self.load_wsgi()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base.py", line 138, in load_wsgi
notify-run_1  |     self.wsgi = self.app.wsgi()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
notify-run_1  |     self.callable = self.load()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load
notify-run_1  |     return self.load_wsgiapp()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
notify-run_1  |     return util.import_app(self.app_uri)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/util.py", line 350, in import_app
notify-run_1  |     __import__(module)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/notify_run_server/__init__.py", line 1, in <module>
notify-run_1  |     from notify_run_server.app import app
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/notify_run_server/app.py", line 40, in <module>
notify-run_1  |     model = SqlNotifyModel()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/notify_run_server/model_sqlalchemy.py", line 43, in __init__
notify-run_1  |     Base.metadata.create_all(engine)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/schema.py", line 4294, in create_all
notify-run_1  |     ddl.SchemaGenerator, self, checkfirst=checkfirst, tables=tables
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 2046, in _run_visitor
notify-run_1  |     conn._run_visitor(visitorcallable, element, **kwargs)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1615, in _run_visitor
notify-run_1  |     visitorcallable(self.dialect, self, **kwargs).traverse_single(element)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 132, in traverse_single
notify-run_1  |     return meth(obj, **kw)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/ddl.py", line 781, in visit_metadata
notify-run_1  |     _is_metadata_operation=True,
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 132, in traverse_single
notify-run_1  |     return meth(obj, **kw)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/ddl.py", line 826, in visit_table
notify-run_1  |     include_foreign_key_constraints,
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 988, in execute
notify-run_1  |     return meth(self, multiparams, params)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/ddl.py", line 72, in _execute_on_connection
notify-run_1  |     return connection._execute_ddl(self, multiparams, params)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1050, in _execute_ddl
notify-run_1  |     compiled,
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1253, in _execute_context
notify-run_1  |     e, statement, parameters, cursor, context
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1473, in _handle_dbapi_exception
notify-run_1  |     util.raise_from_cause(sqlalchemy_exception, exc_info)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 398, in raise_from_cause
notify-run_1  |     reraise(type(exception), exception, tb=exc_tb, cause=cause)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 152, in reraise
notify-run_1  |     raise value.with_traceback(tb)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1249, in _execute_context
notify-run_1  |     cursor, statement, parameters, context
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 552, in do_execute
notify-run_1  |     cursor.execute(statement, parameters)
notify-run_1  | sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) table message already exists
notify-run_1  | [SQL:
notify-run_1  | CREATE TABLE message (
notify-run_1  |         id INTEGER NOT NULL,
notify-run_1  |         channel_id VARCHAR,
notify-run_1  |         "messageTime" DATETIME,
notify-run_1  |         message VARCHAR,
notify-run_1  |         data JSON,
notify-run_1  |         result JSON,
notify-run_1  |         PRIMARY KEY (id),
notify-run_1  |         FOREIGN KEY(channel_id) REFERENCES channel (id)
notify-run_1  | )
notify-run_1  |
notify-run_1  | ]
notify-run_1  | (Background on this error at: http://sqlalche.me/e/e3q8)
notify-run_1  | WARNING: Built-in VAPID keys will be used. For public deployments, use the environment variables VAPID_PRIVKEY and VAPID_PUBKEY to pass your own.
notify-run_1  | /usr/local/lib/python3.7/site-packages/notify_run_server/static
notify-run_1  | WARNING: Built-in VAPID keys will be used. For public deployments, use the environment variables VAPID_PRIVKEY and VAPID_PUBKEY to pass your own.
notify-run_1  | /usr/local/lib/python3.7/site-packages/notify_run_server/static
notify-run_1  | [2019-09-03 15:00:53 +0000] [10] [INFO] Worker exiting (pid: 10)
notify-run_1  | [2019-09-03 15:00:53 +0000] [7] [ERROR] Exception in worker process
notify-run_1  | Traceback (most recent call last):
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1249, in _execute_context
notify-run_1  |     cursor, statement, parameters, context
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 552, in do_execute
notify-run_1  |     cursor.execute(statement, parameters)
notify-run_1  | sqlite3.OperationalError: table channel already exists
notify-run_1  |
notify-run_1  | The above exception was the direct cause of the following exception:
notify-run_1  |
notify-run_1  | Traceback (most recent call last):
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 583, in spawn_worker
notify-run_1  |     worker.init_process()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base.py", line 129, in init_process
notify-run_1  |     self.load_wsgi()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/workers/base.py", line 138, in load_wsgi
notify-run_1  |     self.wsgi = self.app.wsgi()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/base.py", line 67, in wsgi
notify-run_1  |     self.callable = self.load()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 52, in load
notify-run_1  |     return self.load_wsgiapp()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 41, in load_wsgiapp
notify-run_1  |     return util.import_app(self.app_uri)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/util.py", line 350, in import_app
notify-run_1  |     __import__(module)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/notify_run_server/__init__.py", line 1, in <module>
notify-run_1  |     from notify_run_server.app import app
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/notify_run_server/app.py", line 40, in <module>
notify-run_1  |     model = SqlNotifyModel()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/notify_run_server/model_sqlalchemy.py", line 43, in __init__
notify-run_1  |     Base.metadata.create_all(engine)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/schema.py", line 4294, in create_all
notify-run_1  |     ddl.SchemaGenerator, self, checkfirst=checkfirst, tables=tables
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 2046, in _run_visitor
notify-run_1  |     conn._run_visitor(visitorcallable, element, **kwargs)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1615, in _run_visitor
notify-run_1  |     visitorcallable(self.dialect, self, **kwargs).traverse_single(element)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 132, in traverse_single
notify-run_1  |     return meth(obj, **kw)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/ddl.py", line 781, in visit_metadata
notify-run_1  |     _is_metadata_operation=True,
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/visitors.py", line 132, in traverse_single
notify-run_1  |     return meth(obj, **kw)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/ddl.py", line 826, in visit_table
notify-run_1  |     include_foreign_key_constraints,
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 988, in execute
notify-run_1  |     return meth(self, multiparams, params)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/sql/ddl.py", line 72, in _execute_on_connection
notify-run_1  |     return connection._execute_ddl(self, multiparams, params)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1050, in _execute_ddl
notify-run_1  |     compiled,
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1253, in _execute_context
notify-run_1  |     e, statement, parameters, cursor, context
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1473, in _handle_dbapi_exception
notify-run_1  |     util.raise_from_cause(sqlalchemy_exception, exc_info)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 398, in raise_from_cause
notify-run_1  |     reraise(type(exception), exception, tb=exc_tb, cause=cause)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 152, in reraise
notify-run_1  |     raise value.with_traceback(tb)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1249, in _execute_context
notify-run_1  |     cursor, statement, parameters, context
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/default.py", line 552, in do_execute
notify-run_1  |     cursor.execute(statement, parameters)
notify-run_1  | sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) table channel already exists
notify-run_1  | [SQL:
notify-run_1  | CREATE TABLE channel (
notify-run_1  |         id VARCHAR NOT NULL,
notify-run_1  |         created DATETIME,
notify-run_1  |         meta JSON,
notify-run_1  |         subscriptions JSON,
notify-run_1  |         PRIMARY KEY (id)
notify-run_1  | )
notify-run_1  |
notify-run_1  | ]
notify-run_1  | (Background on this error at: http://sqlalche.me/e/e3q8)
notify-run_1  | [2019-09-03 15:00:53 +0000] [7] [INFO] Worker exiting (pid: 7)
notify-run_1  | [2019-09-03 15:00:53 +0000] [8] [INFO] Worker exiting (pid: 8)
notify-run_1  | WARNING: Built-in VAPID keys will be used. For public deployments, use the environment variables VAPID_PRIVKEY and VAPID_PUBKEY to pass your own.
notify-run_1  | /usr/local/lib/python3.7/site-packages/notify_run_server/static
notify-run_1  | [2019-09-03 15:00:53 +0000] [9] [INFO] Worker exiting (pid: 9)
notify-run_1  | WARNING: Built-in VAPID keys will be used. For public deployments, use the environment variables VAPID_PRIVKEY and VAPID_PUBKEY to pass your own.
notify-run_1  | /usr/local/lib/python3.7/site-packages/notify_run_server/static
notify-run_1  | Traceback (most recent call last):
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 210, in run
notify-run_1  |     self.sleep()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 360, in sleep
notify-run_1  |     ready = select.select([self.PIPE[0]], [], [], 1.0)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 245, in handle_chld
notify-run_1  |     self.reap_workers()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 525, in reap_workers
notify-run_1  |     raise HaltServer(reason, self.WORKER_BOOT_ERROR)
notify-run_1  | gunicorn.errors.HaltServer: <HaltServer 'Worker failed to boot.' 3>
notify-run_1  |
notify-run_1  | During handling of the above exception, another exception occurred:
notify-run_1  |
notify-run_1  | Traceback (most recent call last):
notify-run_1  |   File "/usr/local/bin/gunicorn", line 10, in <module>
notify-run_1  |     sys.exit(run())
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/wsgiapp.py", line 61, in run
notify-run_1  |     WSGIApplication("%(prog)s [OPTIONS] [APP_MODULE]").run()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/base.py", line 223, in run
notify-run_1  |     super(Application, self).run()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/app/base.py", line 72, in run
notify-run_1  |     Arbiter(self).run()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 232, in run
notify-run_1  |     self.halt(reason=inst.reason, exit_status=inst.exit_status)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 345, in halt
notify-run_1  |     self.stop()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 393, in stop
notify-run_1  |     time.sleep(0.1)
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 245, in handle_chld
notify-run_1  |     self.reap_workers()
notify-run_1  |   File "/usr/local/lib/python3.7/site-packages/gunicorn/arbiter.py", line 525, in reap_workers
notify-run_1  |     raise HaltServer(reason, self.WORKER_BOOT_ERROR)
notify-run_1  | gunicorn.errors.HaltServer: <HaltServer 'Worker failed to boot.' 3>
notify-run_1  | [2019-09-03 15:00:56 +0000] [1] [INFO] Starting gunicorn 19.9.0
notify-run_1  | [2019-09-03 15:00:56 +0000] [1] [INFO] Listening at: http://0.0.0.0:8000 (1)
notify-run_1  | [2019-09-03 15:00:56 +0000] [1] [INFO] Using worker: sync
notify-run_1  | [2019-09-03 15:00:56 +0000] [7] [INFO] Booting worker with pid: 7
notify-run_1  | [2019-09-03 15:00:56 +0000] [8] [INFO] Booting worker with pid: 8
notify-run_1  | [2019-09-03 15:00:56 +0000] [9] [INFO] Booting worker with pid: 9
notify-run_1  | [2019-09-03 15:00:56 +0000] [10] [INFO] Booting worker with pid: 10
```
The traceback feels a bit like a timing issue, since I am actually not seeing it all the time.